### PR TITLE
Minor refactor of test.ava.js

### DIFF
--- a/tests.ava.js
+++ b/tests.ava.js
@@ -1,8 +1,21 @@
-const test = require('ava').test;
-const path = require('path');
-const del = require('del');
-const srcPath = path.resolve(__dirname, 'tests/mock/src');
-const clear = () => require('del').sync(srcPath);
+// Dependencies
+import test from 'ava';
+import path from 'path';
+import del from 'del';
+// Spec files
+import basicPlopFile from './tests/basic-plopfile';
+import dynamicActions from './tests/dynamic-actions';
+import basicNoPlopfile from './tests/basic-no-plopfile';
+import addActionFailure from './tests/add-action-failure';
+import addActionNoTemplate from './tests/add-action-no-template';
+import missingActionPath from './tests/missing-action-path';
+import abortOnFail from './tests/abort-on-fail';
+import generatorNameAndPrompts from './tests/generator-name-and-prompts';
+
+const clear = () => {
+	const srcPath = path.resolve(__dirname, 'tests/mock/src');
+	del.sync(srcPath);
+}
 
 // clean out the /src dir when done
 test.before(clear);
@@ -15,19 +28,18 @@ test.before(() => process.stdout.write('\u001B[2J\u001B[0;0f'));
 //
 
 // basic action test with plopfile
-test('basic add action', require('./tests/basic-plopfile'));
+test('basic add action', basicPlopFile);
 
 // dynamic actions (the potato tests)
-const dynActions = require('./tests/dynamic-actions');
-test('dynamic actions (yes potato)', dynActions.yesPotatoes);
-test('dynamic actions (no potato)', dynActions.noPotatoes);
+test('dynamic actions (yes potato)', dynamicActions.yesPotatoes);
+test('dynamic actions (no potato)', dynamicActions.noPotatoes);
 
 // tests for using plop with no plopfile
-test('basic add action (no plopfile)', require('./tests/basic-no-plopfile'));
+test('basic add action (no plopfile)', basicNoPlopfile);
 
 // action object interface tests
-test('add action failure (file already exists)', require('./tests/add-action-failure'));
-test('add action with no template', require('./tests/add-action-no-template'));
-test('missing action path', require('./tests/missing-action-path'));
-test('abort on fail', require('./tests/abort-on-fail'));
-test('generator name and prompts', require('./tests/generator-name-and-prompts'));
+test('add action failure (file already exists)', addActionFailure);
+test('add action with no template', addActionNoTemplate);
+test('missing action path', missingActionPath);
+test('abort on fail', abortOnFail);
+test('generator name and prompts', generatorNameAndPrompts);


### PR DESCRIPTION
A minor refactor in test.ava.js to use ES6 import instead of require. Also, regroup all the imports at the beginning of the document to improve the developer experience.

closes #4 