### PR TITLE
Add babel es2015-node preset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,24 +1,3 @@
 {
-	"plugins": [
-		"check-es2015-constants",
-		"transform-es2015-arrow-functions",
-		"transform-es2015-block-scoped-functions",
-		"transform-es2015-block-scoping",
-		"transform-es2015-classes",
-		"transform-es2015-computed-properties",
-		"transform-es2015-destructuring",
-		"transform-es2015-duplicate-keys",
-		"transform-es2015-for-of",
-		"transform-es2015-function-name",
-		"transform-es2015-literals",
-		"transform-es2015-modules-commonjs",
-		"transform-es2015-object-super",
-		"transform-es2015-parameters",
-		"transform-es2015-shorthand-properties",
-		"transform-es2015-spread",
-		"transform-es2015-sticky-regex",
-		"transform-es2015-template-literals",
-		"transform-es2015-typeof-symbol",
-		"transform-es2015-unicode-regex"
-	]
+	"presets": ["es2015-node"]
 }

--- a/package.json
+++ b/package.json
@@ -33,26 +33,7 @@
   "devDependencies": {
     "ava": "^0.16.0",
     "babel-cli": "^6.16.0",
-    "babel-plugin-check-es2015-constants": "^6.8.0",
-    "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
-    "babel-plugin-transform-es2015-block-scoped-functions": "^6.8.0",
-    "babel-plugin-transform-es2015-block-scoping": "^6.8.0",
-    "babel-plugin-transform-es2015-classes": "^6.8.0",
-    "babel-plugin-transform-es2015-computed-properties": "^6.8.0",
-    "babel-plugin-transform-es2015-destructuring": "^6.8.0",
-    "babel-plugin-transform-es2015-duplicate-keys": "^6.8.0",
-    "babel-plugin-transform-es2015-for-of": "^6.8.0",
-    "babel-plugin-transform-es2015-function-name": "^6.8.0",
-    "babel-plugin-transform-es2015-literals": "^6.8.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
-    "babel-plugin-transform-es2015-object-super": "^6.8.0",
-    "babel-plugin-transform-es2015-parameters": "^6.8.0",
-    "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
-    "babel-plugin-transform-es2015-spread": "^6.8.0",
-    "babel-plugin-transform-es2015-sticky-regex": "^6.8.0",
-    "babel-plugin-transform-es2015-template-literals": "^6.8.0",
-    "babel-plugin-transform-es2015-typeof-symbol": "^6.8.0",
-    "babel-plugin-transform-es2015-unicode-regex": "^6.8.0",
+    "babel-preset-es2015-node": "6.1.1",
     "babel-register": "6.18.0"
   },
   "dependencies": {
@@ -77,6 +58,7 @@
     "require": [
       "babel-register"
     ],
+    "babel": "inherit",
     "failFast": true,
     "tap": true
   }


### PR DESCRIPTION
Substitute all Babel plugins for a es2015-node preset. 

More information about #13 

closes #13 