### PR TITLE
Windows 7 compatibility update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ lib
 
 # Test mocks
 tests/*-mock/src
+
+# IDE files
+.idea

--- a/src/modules/node-plop.js
+++ b/src/modules/node-plop.js
@@ -153,7 +153,7 @@ function nodePlop(plopfilePath = '', plopCfg = {}) {
 
 	if (plopfilePath) {
 		plopfilePath = path.resolve(plopfilePath);
-		const plopFileName = path.posix.basename(plopfilePath);
+		const plopFileName = path.basename(plopfilePath);
 		setPlopfilePath(plopfilePath);
 		require(path.join(plopfilePath, plopFileName))(plopApi, plopCfg);
 	}


### PR DESCRIPTION
Changed the path.posix.basename call to path.basename.

Prior to this fix, the posix call was returning the full path + file.

As an example the file path plop was trying to pull would look something like

`C:/path/to/plopfile/C:/path/to/plopfile/plopfile.js`