### PR TITLE
addMany action not working on windows

### DIFF
--- a/src/actions/addMany.js
+++ b/src/actions/addMany.js
@@ -15,7 +15,7 @@ export default co.wrap(function* (data, cfg, plop) {
 	const filesAdded = [];
 	for (let templateFile of templateFiles) {
 		const fileCfg = Object.assign({}, cfg, {
-			path: resolvePath(cfg.destination, templateFile, cfg.base),
+			path: toUnix(resolvePath(cfg.destination, templateFile, cfg.base)),
 			templateFile: templateFile
 		});
 
@@ -25,6 +25,14 @@ export default co.wrap(function* (data, cfg, plop) {
 
 	return `${filesAdded.length} files added\n -> ${filesAdded.join('\n -> ')}`;
 });
+
+/**
+ * This function converts a non POSIX/UNIX path to it
+ * @param {string} path The path to convert to POSIX/UNIX format 
+ */
+function toUnix(path) {
+	return !path.sep || path.sep === '\\'  ? path.replace(/\\/g, '/') : path;
+}
 
 function resolveTemplateFiles(templateFilesGlob, basePath, plop) {
 	return globby.sync(templateFilesGlob, { cwd: plop.getPlopfilePath() })
@@ -53,7 +61,7 @@ function dropFileRootPath(file, rootPath) {
 }
 
 function dropFileRootFolder(file) {
-	const fileParts = file.split(path.sep);
+	const fileParts = path.normalize(file).split(path.sep);
 	fileParts.shift();
 
 	return fileParts.join(path.sep);


### PR DESCRIPTION
Hi!, this PR fixes the `addMany` action when running it on windows based systems.

It was faced some issues with [handlerbar templates](https://github.com/amwmedia/node-plop/blob/master/src/node-plop.js#L32) when trying to compile a template containing a  window path, which was resolve by converting it to an unix path. There was also an issue regarding the [dropFileRootFolder](https://github.com/amwmedia/node-plop/blob/master/src/actions/addMany.js#L55) when the variable `file` is given as an unix path while the `path.sep` is the windows one, which was solved by normalizing to a window path.

Whereas I just tried to modify as fewer lines of code as possible, it is maybe a best option to make a small refactor in the way we deal with paths as described for instance by [upath](https://github.com/anodynos/upath#why-) project. I'm also attaching test reports before & after the fix.

Whatever you find wrong with this PR let me know please and hope this may help. 

Thank you so much. 

[test_report_before.txt](https://github.com/amwmedia/node-plop/files/1273158/test_report_before.txt)
[test_report_after.txt](https://github.com/amwmedia/node-plop/files/1273157/test_report_after.txt)