### PR TITLE
Parse templateFile for add / modify actions

### DIFF
--- a/src/actions/add.js
+++ b/src/actions/add.js
@@ -6,5 +6,9 @@ export default co.wrap(function* (data, cfg, plop) {
 	const interfaceTestResult = actionInterfaceTest(cfg);
 	if (interfaceTestResult !== true) { throw interfaceTestResult; }
 
+	if (cfg.templateFile) {
+		cfg.templateFile = plop.renderString(cfg.templateFile, data);
+	}
+
 	return yield addFile(data, cfg, plop);
 });

--- a/src/actions/modify.js
+++ b/src/actions/modify.js
@@ -16,7 +16,8 @@ export default co.wrap(function* (data, cfg, plop) {
 
 	try {
 		if (cfg.templateFile) {
-			template = yield fspp.readFile(makeTmplPath(cfg.templateFile));
+			const templateFile = plop.renderString(cfg.templateFile, data);
+			template = yield fspp.readFile(makeTmplPath(templateFile));
 		}
 		if (template == null) { template = ''; }
 

--- a/tests/dynamic-template-file-mock/plop-templates/bar-chart.txt
+++ b/tests/dynamic-template-file-mock/plop-templates/bar-chart.txt
@@ -1,0 +1,2 @@
+this is a bar chart
+name: {{name}}

--- a/tests/dynamic-template-file-mock/plop-templates/change-me.txt
+++ b/tests/dynamic-template-file-mock/plop-templates/change-me.txt
@@ -1,0 +1,5 @@
+-- APPEND ITEMS HERE --
+
++++++++++++++++++++++++++++++++++++++++
+
+-- PREPEND ITEMS HERE --

--- a/tests/dynamic-template-file-mock/plop-templates/line-chart.txt
+++ b/tests/dynamic-template-file-mock/plop-templates/line-chart.txt
@@ -1,0 +1,2 @@
+this is a line chart
+name: {{name}}

--- a/tests/dynamic-template-file-mock/plopfile.js
+++ b/tests/dynamic-template-file-mock/plopfile.js
@@ -1,0 +1,40 @@
+module.exports = function (plop) {
+	'use strict';
+
+	plop.setGenerator('dynamic-template-add', {
+		description: 'adds a file using a dynamic template',
+		prompts: [
+			{
+				type: 'input',
+				name: 'name',
+				message: 'What is your name?',
+				validate: function (value) {
+					if ((/.+/).test(value)) { return true; }
+					return 'name is required';
+				}
+			}, {
+				type: 'list',
+				name: 'kind',
+				message: 'What kind of widget do you want to create?',
+				choices: ['LineChart', 'BarChart'],
+			}
+		],
+		actions: [
+			{
+				type: 'add',
+				path: 'src/{{dashCase name}}.txt',
+				templateFile: 'plop-templates/{{dashCase kind}}.txt',
+				abortOnFail: true
+			}, {
+				type: 'add',
+				path: 'src/change-me.txt',
+				templateFile: 'plop-templates/change-me.txt'
+			}, {
+				type: 'modify',
+				path: 'src/change-me.txt',
+				pattern: /(-- APPEND ITEMS HERE --)/gi,
+				templateFile: 'plop-templates/{{dashCase kind}}.txt'
+			}
+		]
+	});
+};

--- a/tests/dynamic-template-file.ava.js
+++ b/tests/dynamic-template-file.ava.js
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import AvaTest from './_base-ava-test';
+const {test, mockPath, testSrcPath, nodePlop} = new AvaTest(__filename);
+
+const plop = nodePlop(`${mockPath}/plopfile.js`);
+const dynamicTemplateAdd = plop.getGenerator('dynamic-template-add');
+
+test.before(() => {
+	return dynamicTemplateAdd.runActions({name: 'this is a test', kind: 'LineChart'});
+});
+
+test('Check that the file has been created', t => {
+	const filePath = path.resolve(testSrcPath, 'this-is-a-test.txt');
+	t.true(fs.existsSync(filePath));
+});
+
+test('Test file this-is-a-test.txt has been rendered from line-chart.txt', t => {
+	const filePath = path.resolve(testSrcPath, 'this-is-a-test.txt');
+	const content = fs.readFileSync(filePath).toString();
+
+	t.true(content.includes('this is a line chart'));
+	t.true(content.includes('name: this is a test'));
+});
+
+test('Test file change-me.txt has been updated with line-chart.txt', t => {
+	const filePath = path.resolve(testSrcPath, 'change-me.txt');
+	const content = fs.readFileSync(filePath).toString();
+
+	t.true(content.includes('this is a line chart'));
+	t.true(content.includes('name: this is a test'));
+});


### PR DESCRIPTION
Allow dynamic `templateFile` to work for `add` and `modify` actions, as discussed in https://github.com/amwmedia/plop/issues/15.