### PR TITLE
Allow control over globby using addMany

### DIFF
--- a/tests/addMany-multiple-files-mock/plopfile.js
+++ b/tests/addMany-multiple-files-mock/plopfile.js
@@ -46,7 +46,8 @@ module.exports = function (plop) {
 			{
 				type: 'addMany',
 				destination: 'src/{{dashCase name}}-dot/',
-				templateFiles: globSync => globSync('plop-templates/*',{dot:true}),
+				templateFiles: ()=> 'plop-templates/*',
+				globbyOptions: {dot:true},
 				abortOnFail: true
 			}
 		]

--- a/tests/addMany-multiple-files-mock/plopfile.js
+++ b/tests/addMany-multiple-files-mock/plopfile.js
@@ -42,6 +42,12 @@ module.exports = function (plop) {
 				],
 				base: 'plop-templates/',
 				abortOnFail: true
+			},
+			{
+				type: 'addMany',
+				destination: 'src/{{dashCase name}}-dot/',
+				templateFiles: globSync => globSync('plop-templates/*',{dot:true}),
+				abortOnFail: true
 			}
 		]
 	});

--- a/tests/addMany-multiple-files.ava.js
+++ b/tests/addMany-multiple-files.ava.js
@@ -102,4 +102,17 @@ test('Test the base value is used to decide which files are created', t => {
 		const filePath = path.resolve(testSrcPath, file);
 		t.false(fs.existsSync(filePath), `Shouldn't resolve ${filePath}`);
 	});
-})
+});
+
+test('Check that all files including dot have been created', t => {
+	const expectedFiles = [
+		'john-doe-dot/.gitignore',
+		'john-doe-dot/add.txt',
+		'john-doe-dot/another-add.txt'
+	];
+	expectedFiles.map((file) => {
+		const filePath = path.resolve(testSrcPath, file);
+		t.true(fs.existsSync(filePath), `Can't resolve ${filePath}`);
+	});
+	t.true(multipleAddsResult.changes[4].path.includes(`${expectedFiles.length} files added`));
+});


### PR DESCRIPTION
This PR allows templateFiles of addMany to be a function. Usage:
```
{
      type: 'addMany',
      destination: '{{destination}}',
      base: 'templates/javascript/library/rollup',
      templateFiles: globbySync => globbySync('templates/javascript/library/rollup/**/*',{dot:true})
}
```
Globbysync is not globby directly, but a wrapper to `globby.sync`. The `cwd` option is still set. 
`data,cfg,plop` are also passed as parameters. `(globbySync,data,cfg,plop)=>..`
Also: the resulting patterns are still rendered by plop. 

I also changed the validation of isFile, because it depended on an extension being available and that is not a requirement for a file. 

I think this solves https://github.com/amwmedia/node-plop/issues/48 , check the test for this use case. 

