### PR TITLE
use custom data in action definition for path templates

### DIFF
--- a/src/actions/_common-action-utils.js
+++ b/src/actions/_common-action-utils.js
@@ -1,8 +1,12 @@
 import path from 'path';
 import * as fspp from '../fs-promise-proxy';
 
+const getFullData = (data, cfg) => Object.assign({}, cfg.data, data);
 export const makeDestPath = (data, cfg, plop) =>
-	path.resolve(plop.getDestBasePath(), plop.renderString(cfg.path || '', data));
+	path.resolve(
+		plop.getDestBasePath(),
+		plop.renderString(cfg.path || '', getFullData(data, cfg))
+	);
 
 export function* getTemplate(data, cfg, plop) {
 	const makeTmplPath = p => path.resolve(plop.getPlopfilePath(), p);
@@ -10,7 +14,10 @@ export function* getTemplate(data, cfg, plop) {
 	let { template } = cfg;
 
 	if (cfg.templateFile) {
-		const templateFile = plop.renderString(cfg.templateFile, data);
+		const templateFile = plop.renderString(
+			cfg.templateFile,
+			getFullData(data, cfg)
+		);
 		template = yield fspp.readFile(makeTmplPath(templateFile));
 	}
 	if (template == null) {
@@ -22,7 +29,8 @@ export function* getTemplate(data, cfg, plop) {
 
 export function* getRenderedTemplate(data, cfg, plop) {
 	const template = yield getTemplate(data, cfg, plop);
-	return plop.renderString(template, data);
+
+	return plop.renderString(template, getFullData(data, cfg));
 }
 
 export const getRelativeToBasePath = (filePath, plop) =>


### PR DESCRIPTION
if you add custom data to an action like this:

```
  {
        data: {
           foo: "bar"
        },
        type: 'add',
        path: '/path/to/{{foo}}.js',
        templateFile: `path/to/template`
      },
```

the custom data is now used to render the path template. So `{{foo}}` will evaulate to `bar`

This change is useful if you share path-templates across actions where some actions use prompts and others use default values.