### PR TITLE
Append template to end of file if no pattern was provided

### DIFF
--- a/src/actions/append.js
+++ b/src/actions/append.js
@@ -27,6 +27,17 @@ const doAppend = function*(data, cfg, plop, fileData) {
 	}
 
 	const { separator = '\n' } = cfg;
+
+	// add the appended string to the end of the "fileData" if "pattern"
+	// was not provided, i.e. null or false
+	if (!cfg.pattern) {
+		// make sure to add a "separator" if "fileData" is not empty
+		if (fileData.length > 0) {
+			fileData += separator;
+		}
+		return fileData + stringToAppend;
+	}
+
 	return fileData.replace(cfg.pattern, '$&' + separator + stringToAppend);
 };
 

--- a/tests/append-empty-mock/package.json
+++ b/tests/append-empty-mock/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "basic-plopfile-test",
+	"private": true,
+	"config": {
+		"nested": [
+			"basic-plopfile-test-propertyPath-value-index-0",
+			"basic-plopfile-test-propertyPath-value-index-1"
+		]
+	}
+}

--- a/tests/append-empty-mock/plopfile.js
+++ b/tests/append-empty-mock/plopfile.js
@@ -1,0 +1,55 @@
+module.exports = function (plop) {
+	'use strict';
+
+	plop.setGenerator('make-list', {
+		prompts: [
+			{
+				type: 'input',
+				name: 'listName',
+				message: 'What\'s the list name?',
+				validate: function (value) {
+					if ((/.+/).test(value)) { return true; }
+					return 'name is required';
+				}
+			}
+		],
+		actions: [
+			{
+				type: 'add',
+				path: 'src/{{listName}}.txt',
+				templateFile: 'plop-templates/list.txt',
+			},
+		]
+	});
+
+	plop.setGenerator('append-to-list', {
+		description: 'adds entry to a list',
+		prompts: [
+			{
+				type: 'input',
+				name: 'listName',
+				message: 'What\'s the list name?',
+				validate: function (value) {
+					if ((/.+/).test(value)) { return true; }
+					return 'name is required';
+				}
+			},
+			{
+				type: 'input',
+				name: 'name',
+				message: 'What is your name?',
+				validate: function (value) {
+					if ((/.+/).test(value)) { return true; }
+					return 'name is required';
+				}
+			}
+		],
+		actions: [
+			{
+				type: 'append',
+				path: 'src/{{listName}}.txt',
+				template: '{{name}}',
+			}
+		]
+	});
+};

--- a/tests/append-empty.ava.js
+++ b/tests/append-empty.ava.js
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+import co from 'co';
+import AvaTest from './_base-ava-test';
+const {test, mockPath, testSrcPath, nodePlop} = new AvaTest(__filename);
+
+const plop = nodePlop(`${mockPath}/plopfile.js`);
+const makeList = plop.getGenerator('make-list');
+const appendToList = plop.getGenerator('append-to-list');
+
+test('Check if entry will be appended', co.wrap(function* (t) {
+	yield makeList.runActions({listName: 'test'});
+	yield appendToList.runActions({listName: 'test', name: 'Marco'});
+	yield appendToList.runActions({listName: 'test', name: 'Polo'});
+	const filePath = path.resolve(testSrcPath, 'test.txt');
+	const content = fs.readFileSync(filePath).toString();
+
+	t.is(content, 'Marco\nPolo');
+}));


### PR DESCRIPTION
I couldn't find a `pattern` that would allow me to append a template to an empty file. I tried `''`, `/.*/`, `/$/` and `/\z/` but none of them worked as intended.

This PR adds an option where if `pattern` was skipped (`undefined`) or passed as `false` or `null`, the template would be appended to the end of the file regardless of the file's contents.