### PR TITLE
bypass runs validate function if present

### DIFF
--- a/src/prompt-bypass.js
+++ b/src/prompt-bypass.js
@@ -135,6 +135,16 @@ export default function (prompts, bypassArr, plop) {
 			// if inquirer prompt has a filter function - call it
 			const answer = p.filter ? p.filter(value) : value;
 
+			// if inquirer prompt has a validate function - call it
+			if (p.validate) {
+				const validation = p.validate(value);
+				if (validation !== true) {
+					// if validation failed return validation error
+					bypassFailures.push(validation);
+					return false;
+				}
+			}
+
 			answers[p.name] = answer; 
 		} catch(err) {
 			// if we encounter an error above... assume the bypass value was invalid

--- a/tests/prompt-bypass-validate.ava.js
+++ b/tests/prompt-bypass-validate.ava.js
@@ -1,0 +1,19 @@
+import AvaTest from './_base-ava-test';
+import promptBypass from '../lib/prompt-bypass';
+
+const {test, nodePlop} = (new AvaTest(__filename));
+const plop = nodePlop();
+
+const prompts = [{
+	type:'input', name:'input', message:'inputMsg',
+	validate: (value) => value === 'invalid' ? 'Is invalid' : true
+}];
+
+test('verify valid bypass input', function (t) {
+	const [, isValid] = promptBypass(prompts, ['valid'], plop);
+	t.is(isValid.input, 'valid');
+});
+
+test('verify bad bypass input', function (t) {
+	t.throws(() => promptBypass(prompts, ['invalid'], plop));
+});


### PR DESCRIPTION
Any reason this wasn't implemented before? Couldn't see any benefit to not running validation