### PR TITLE
Corrected type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -111,5 +111,5 @@ export interface PlopCfg {
   destBasePath: string;
 }
 
-declare function nodePlop(plopfilePath: string, plopCfg: PlopCfg): NodePlopAPI;
+declare function nodePlop(plopfilePath: string, plopCfg?: PlopCfg): NodePlopAPI;
 export default nodePlop;


### PR DESCRIPTION
The second parameter of the `nodePlop` function is optional, so the TypeScript types should reflect that.  Otherwise TypeScript complains when you don't manually supply it.