### PR TITLE
fix: Adopt Node.js-style module resolution

### DIFF
--- a/src/node-plop.js
+++ b/src/node-plop.js
@@ -83,7 +83,7 @@ function nodePlop(plopfilePath = '', plopCfg = {}) {
 		}, loadCfg);
 
 		targets.forEach(function (target) {
-			const targetPath = resolve.sync(target, {basedir: getPlopfilePath()});
+			const targetPath = resolve.sync(target, {basedir: getPlopfilePath(), preserveSymlinks: false});
 			const proxy = nodePlop(targetPath, config);
 			const proxyDefaultInclude = proxy.getDefaultInclude() || {};
 			const includeCfg = includeOverride || proxyDefaultInclude;


### PR DESCRIPTION
`plop.load` uses the `resolve` module to resolve modules on behalf of the user. (So they don't have to `require` in the module themselves.) However v1 of `resolve` preserves symlinks by default whereas Node.js does not. Therefore we should explicitly set the `preserveSymlinks` flag to `false` in order to get the desired Node.js-like behaviour.

Specifically, this causes problems when a module that is `plop.load`ed tries to `plop.load` another module and you have installed your modules using [pnpm](https://pnpm.js.org/). (It might happen with normal npm as well; I've not tested. pnpm make extensive use of symlinks though so that is likely why it exposes this problem.)

See:
1. https://github.com/browserify/resolve/issues/226
2. https://github.com/browserify/resolve/blob/1.x/readme.markdown#resolveid-opts-cb