### PR TITLE
Add builtin actions to a plop's set of action types

### DIFF
--- a/src/generator-runner.js
+++ b/src/generator-runner.js
@@ -1,8 +1,6 @@
 'use strict';
 
 import promptBypass from './prompt-bypass';
-import * as buildInActions from './actions';
-
 
 export default function (plopfileApi, flags) {
 	let abort;
@@ -39,8 +37,7 @@ export default function (plopfileApi, flags) {
 		const changes = [];          // array of changed made by the actions
 		const failures = [];         // array of actions that failed
 		let {actions} = genObject;   // the list of actions to execute
-		const customActionTypes = getCustomActionTypes();
-		const actionTypes = Object.assign({}, customActionTypes, buildInActions);
+		const actionTypes = getActionTypes();
 
 		abort = false;
 
@@ -118,7 +115,7 @@ export default function (plopfileApi, flags) {
 		if (typeof cfg.skip === 'function') {
 			// Merge main data and config data in new object
 			const reasonToSkip = await cfg.skip({ ...data, ...cfgData });
-			
+
 			if (typeof reasonToSkip === 'string') {
 				// Return actionResult instead of string
 				return {
@@ -157,7 +154,7 @@ export default function (plopfileApi, flags) {
 	};
 
 	// request the list of custom actions from the plopfile
-	function getCustomActionTypes() {
+	function getActionTypes() {
 		return plopfileApi.getActionTypeList().reduce(function(types, name) {
 			types[name] = plopfileApi.getActionType(name);
 			return types;

--- a/src/node-plop.js
+++ b/src/node-plop.js
@@ -7,6 +7,7 @@ import resolve from 'resolve';
 
 import bakedInHelpers from './baked-in-helpers';
 import generatorRunner from './generator-runner';
+import * as buildInActions from './actions';
 
 function nodePlop(plopfilePath = '', plopCfg = {}) {
 
@@ -17,7 +18,7 @@ function nodePlop(plopfilePath = '', plopCfg = {}) {
 	const {destBasePath, force} = plopCfg;
 	const generators = {};
 	const partials = {};
-	const actionTypes = {};
+	const actionTypes = { ...buildInActions };
 	const helpers = Object.assign({
 		pkg: (propertyPath) => _get(pkgJson, propertyPath, '')
 	}, bakedInHelpers);

--- a/tests/get-action-type-list.ava.js
+++ b/tests/get-action-type-list.ava.js
@@ -1,0 +1,21 @@
+import AvaTest from "./_base-ava-test";
+const { test, nodePlop } = new AvaTest(__filename);
+
+const plop = nodePlop();
+
+test("custom actions show in the list", function (t) {
+  plop.setActionType("foo", () => {});
+
+  const list = plop.getActionTypeList();
+
+  t.true(list.includes("foo"));
+});
+
+test("default actions are present", function (t) {
+  const list = plop.getActionTypeList();
+
+  t.true(list.includes("add"), "add");
+  t.true(list.includes("modify"), "modify");
+  t.true(list.includes("addMany"), "addMany");
+  t.true(list.includes("append"), "append");
+});

--- a/tests/load-assets-from-plopfile.ava.js
+++ b/tests/load-assets-from-plopfile.ava.js
@@ -74,7 +74,7 @@ test('plop.load passes a config object that can be used to change the plopfile o
 	t.is(gNameList.length, 3);
 	t.is(plop.getHelperList().length, 3);
 	t.is(plop.getPartialList().length, 3);
-	t.is(plop.getActionTypeList().length, 1);
+	t.is(plop.getActionTypeList().length, 5);
 	t.true(gNameList.includes('test-generator1'));
 	t.true(plop.getHelperList().includes('test-helper2'));
 	t.true(plop.getPartialList().includes('test-partial3'));


### PR DESCRIPTION
Mostly so that I can go `plop.getActionType('add')` (or any other built-in action) from a plopfile and get it.