### PR TITLE
Shorthand to load all plop assets

### DIFF
--- a/src/node-plop.js
+++ b/src/node-plop.js
@@ -95,10 +95,10 @@ function nodePlop(plopfilePath = '', plopCfg = {}) {
 			}, includeCfg);
 
 			const genNameList = proxy.getGeneratorList().map(g => g.name);
-			loadAsset(genNameList, include.generators, setGenerator, proxyName => ({proxyName, proxy}));
-			loadAsset(proxy.getPartialList(), include.partials, setPartial, proxy.getPartial);
-			loadAsset(proxy.getHelperList(), include.helpers, setHelper, proxy.getHelper);
-			loadAsset(proxy.getActionTypeList(), include.actionTypes, setActionType, proxy.getActionType);
+			loadAsset(genNameList, includeCfg===true || include.generators, setGenerator, proxyName => ({proxyName, proxy}));
+			loadAsset(proxy.getPartialList(), includeCfg===true || include.partials, setPartial, proxy.getPartial);
+			loadAsset(proxy.getHelperList(), includeCfg===true || include.helpers, setHelper, proxy.getHelper);
+			loadAsset(proxy.getActionTypeList(), includeCfg===true || include.actionTypes, setActionType, proxy.getActionType);
 		});
 	}
 

--- a/tests/load-assets-from-plopfile.ava.js
+++ b/tests/load-assets-from-plopfile.ava.js
@@ -81,6 +81,21 @@ test('plop.load passes a config object that can be used to change the plopfile o
 	t.true(plop.getActionTypeList().includes('test-actionType1'));
 });
 
+test('plop.load passes a config option that can be used to include all the plopfile output', function (t) {
+	const plop = nodePlop();
+	plop.load(plopfilePath, {prefix: 'test-'}, true);
+
+	const gNameList = plop.getGeneratorList().map(g => g.name);
+	t.is(gNameList.length, 3);
+	t.is(plop.getHelperList().length, 3);
+	t.is(plop.getPartialList().length, 3);
+	t.is(plop.getActionTypeList().length, 1);
+	t.true(gNameList.includes('test-generator1'));
+	t.true(plop.getHelperList().includes('test-helper2'));
+	t.true(plop.getPartialList().includes('test-partial3'));
+	t.true(plop.getActionTypeList().includes('test-actionType1'));
+});
+
 test('plop.load should import functioning assets', function (t) {
 	const plop = nodePlop();
 	plop.load(plopfilePath, {prefix: 'test-'}, {


### PR DESCRIPTION
Currently the `load` function doesn't include all assets when the `includeCfg` option is set to `true`.
The suggested code change should allow a shorthand to include all assets:
```js
plop.load('plopfile', {}, true)
```